### PR TITLE
Doomgame screenbuffer output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@
 /build_vc2019-64
 /build_vc2019-32
 *.code-workspace
+cmake-build*/
+.idea/

--- a/include/gvizdoom/DoomGame.hpp
+++ b/include/gvizdoom/DoomGame.hpp
@@ -14,6 +14,7 @@
 #include "gvizdoom/Action.hpp"
 #include "gvizdoom/GameConfig.hpp"
 #include "d_main.h"
+#include "v_video.h"
 
 
 namespace gvizdoom {
@@ -33,12 +34,17 @@ public:
     bool update(const Action& action); // returns true upon exit
     int getStatus() const;
 
-    // TODO getter(s) for updated game state
+    int getScreenWidth() const;
+    int getScreenHeight() const;
+    uint8_t* getPixelsRGBA() const;
+    float* getPixelsDepth() const;
+    void updateCanvas();
 
 private:
     GameConfig                  _gameConfig;
     int                         _status;
     D_DoomMain_Internal_State   _state;
+    const DCanvas*              _canvas;
 };
 
 } // namespace gvizdoom

--- a/include/gvizdoom/DoomGame.hpp
+++ b/include/gvizdoom/DoomGame.hpp
@@ -23,9 +23,9 @@ class DoomGame {
 public:
     DoomGame();
     DoomGame(const DoomGame&) = delete;
-    DoomGame(DoomGame&&);
+    DoomGame(DoomGame&&) = default;
     DoomGame& operator=(const DoomGame&) = delete;
-    DoomGame& operator=(DoomGame&&);
+    DoomGame& operator=(DoomGame&&) = default;
     ~DoomGame();
 
     void init(GameConfig&& gameConfig);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1264,12 +1264,14 @@ target_include_directories(gvizdoom_client
 PUBLIC
 	../include
 	${SDL2_INCLUDE_DIR}
-)
+	${OpenCV_INCLUDE_DIRS} # TODO opencv temp
+	)
 
 target_link_libraries(gvizdoom_client
 PUBLIC
 	gvizdoom
 	${SDL2_LIBRARY}
+	${OpenCV_LIBS} # TODO opencv temp
 )
 
 set_source_files_properties( ${FASTMATH_SOURCES} PROPERTIES COMPILE_FLAGS ${ZD_FASTMATH_FLAG} )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -379,7 +379,6 @@ endif()
 
 # TODO opencv temp
 find_package(OpenCV REQUIRED)
-set( PROJECT_LIBRARIES ${PROJECT_LIBRARIES} ${OpenCV_LIBS} )
 # TODO end of opencv temp
 
 # Start defining source files for ZDoom
@@ -1297,9 +1296,6 @@ target_include_directories( zdoom PUBLIC ${OpenCV_INCLUDE_DIRS} )
 #TODO end of opencv temp
 
 target_link_libraries(gvizdoom ${PROJECT_LIBRARIES} gdtoa lzma ${ZMUSIC_LIBRARIES} )
-#TODO opencv temp
-target_include_directories(gvizdoom PUBLIC ${OpenCV_INCLUDE_DIRS} )
-#TODO end of opencv temp
 
 set_target_properties(gvizdoom gvizdoom_client
 	PROPERTIES

--- a/src/common/rendering/v_video.h
+++ b/src/common/rendering/v_video.h
@@ -108,7 +108,7 @@ public:
 
 	// Member variable access
 	inline uint8_t *GetPixels () const { return Pixels.Data(); }
-    inline float *GetDepthPixels () { return DepthPixels.Data(); }
+    inline float *GetDepthPixels () const { return DepthPixels.Data(); }
 	inline int GetWidth () const { return Width; }
 	inline int GetHeight () const { return Height; }
 	inline int GetPitch () const { return Pitch; }

--- a/src/gvizdoom/DoomGame.cpp
+++ b/src/gvizdoom/DoomGame.cpp
@@ -13,6 +13,9 @@
 #include "engineerrors.h"
 
 
+const DCanvas* GetCanvas(); // TODO remove once proper way of fetching canvas is implemented
+
+
 using namespace gvizdoom;
 
 

--- a/src/gvizdoom/DoomGame.cpp
+++ b/src/gvizdoom/DoomGame.cpp
@@ -24,21 +24,6 @@ DoomGame::DoomGame() :
 {
 }
 
-DoomGame::DoomGame(DoomGame&& other) :
-    _gameConfig (other._gameConfig),
-    _status     (other._status),
-    _state      (other._state)
-{
-}
-
-DoomGame& DoomGame::operator=(DoomGame&& other)
-{
-    _gameConfig = other._gameConfig;
-    _status     = other._status;
-    _state      = other._state;
-    return *this;
-}
-
 DoomGame::~DoomGame()
 {
     GameMain_Cleanup();

--- a/src/gvizdoom/DoomGame.cpp
+++ b/src/gvizdoom/DoomGame.cpp
@@ -20,7 +20,8 @@ using namespace gvizdoom;
 
 
 DoomGame::DoomGame() :
-    _status (-1)
+    _status (-1),
+    _canvas (nullptr)
 {
 }
 
@@ -94,4 +95,38 @@ bool DoomGame::update(const Action& action)
 int DoomGame::getStatus() const
 {
     return _status;
+}
+
+int DoomGame::getScreenWidth() const
+{
+    if (_canvas == nullptr)
+        return 0;
+    return _canvas->GetWidth();
+}
+
+int DoomGame::getScreenHeight() const
+{
+    if (_canvas == nullptr)
+        return 0;
+    return _canvas->GetHeight();
+}
+
+uint8_t* DoomGame::getPixelsRGBA() const
+{
+    if (_canvas == nullptr)
+        return nullptr;
+    return _canvas->GetPixels();
+}
+
+float* DoomGame::getPixelsDepth() const
+{
+    if (_canvas == nullptr)
+        return nullptr;
+    return _canvas->GetDepthPixels();
+}
+
+void DoomGame::updateCanvas()
+{
+    if (_canvas == nullptr)
+        _canvas = GetCanvas();
 }

--- a/src/gvizdoom_client/App.cpp
+++ b/src/gvizdoom_client/App.cpp
@@ -39,8 +39,7 @@ App::App(
         SDL_WINDOWPOS_UNDEFINED,
         (int)_settings.window.width,
         (int)_settings.window.height,
-        SDL_WINDOW_SHOWN | SDL_WINDOW_OPENGL);
-
+        SDL_WINDOW_SHOWN);
     if (_window == nullptr) {
         printf("Error: SDL Window could not be created! SDL_Error: %s\n", SDL_GetError());
         return;

--- a/src/gvizdoom_client/App.cpp
+++ b/src/gvizdoom_client/App.cpp
@@ -10,6 +10,8 @@
 
 #include "gvizdoom_client/App.hpp"
 
+#include <opencv2/opencv.hpp>
+
 
 using namespace gvizdoom;
 
@@ -79,6 +81,23 @@ void App::loop(void)
         _quit = _doomGame->update(Action());
         if (_quit)
             break;
+
+        // TODO opencv temp
+        _doomGame->updateCanvas();
+        if (_doomGame->getPixelsRGBA() != nullptr) {
+            auto h = _doomGame->getScreenHeight();
+            auto w = _doomGame->getScreenWidth();
+
+            // render RGBA
+            cv::Mat rgbaMat(h, w, CV_8UC4, _doomGame->getPixelsRGBA());
+            cv::imshow("rgba", rgbaMat);
+
+            // render depth
+            cv::Mat depthMat(h, w, CV_32FC1, _doomGame->getPixelsDepth());
+            cv::imshow("depth", depthMat);
+            cv::waitKey(1);
+        }
+        // TODO end of opencv temp
 
         // User-defined render
         if (_renderContext != nullptr && _settings.render != nullptr)

--- a/src/rendering/hwrenderer/hw_entrypoint.cpp
+++ b/src/rendering/hwrenderer/hw_entrypoint.cpp
@@ -63,6 +63,13 @@ void CleanSWDrawer()
 	swdrawer = nullptr;
 }
 
+const DCanvas* GetCanvas()
+{
+    if (swdrawer)
+        return swdrawer->getCanvas();
+    return nullptr;
+}
+
 #include "g_levellocals.h"
 #include "a_dynlight.h"
 

--- a/src/rendering/swrenderer/r_swscene.cpp
+++ b/src/rendering/swrenderer/r_swscene.cpp
@@ -39,9 +39,6 @@
 #include "d_main.h"
 #include "v_draw.h"
 
-// TODO opencv temp
-#include <opencv2/opencv.hpp>
-// TODO end of opencv temp
 
 // [RH] Base blending values (for e.g. underwater)
 int BaseBlendR, BaseBlendG, BaseBlendB;
@@ -133,14 +130,6 @@ sector_t *SWSceneDrawer::RenderView(player_t *player)
 			screen->Draw2D();
 			twod->Clear();
 		});
-
-        // TODO opencv temp
-        {
-            cv::Mat depthMat(Canvas->GetHeight(), Canvas->GetWidth(), CV_32FC1, Canvas->GetDepthPixels());
-            cv::imshow("depth", depthMat);
-            cv::waitKey(1);
-        }
-        // TODO end of opencv temp
 	}
 	else
 	{

--- a/src/rendering/swrenderer/r_swscene.h
+++ b/src/rendering/swrenderer/r_swscene.h
@@ -24,5 +24,6 @@ public:
 	~SWSceneDrawer();
 
 	sector_t *RenderView(player_t *player);
+    const DCanvas* getCanvas() const { return Canvas.get(); }
 };
 


### PR DESCRIPTION
- Remove OpenCV from `gvizdoom` target
- Implement interface for fetching canvas dimensions and RGBA/depth pixels in DoomGame
- Use OpenCV to render the RGBA and depth frames in `App` by utilizing the aforementioned interface