### PR TITLE
Restart hotfix

### DIFF
--- a/src/doom/d_main.cpp
+++ b/src/doom/d_main.cpp
@@ -2229,6 +2229,8 @@ void DoomMain::ReInit(gvizdoom::Context& context, const gvizdoom::GameConfig& ga
 {
     // reinit from here
 
+    singletics = !gameConfig.interactive;
+
     // use static rng seed
     rngseed = 69420;
     FRandom::StaticClearRandom ();

--- a/src/gvizdoom/DoomGame.cpp
+++ b/src/gvizdoom/DoomGame.cpp
@@ -170,6 +170,10 @@ void DoomGame::reinit()
     _context.frameBuffer = std::make_unique<HeadlessFrameBuffer>(
         _gameConfig.videoWidth, _gameConfig.videoHeight, _gameConfig.videoTrueColor);
 
+    // Reset the game states blocking updates
+    _gameState.set<GameState::LevelFinished>(false);
+    _gameState.set<GameState::PlayerDead>(false);
+
     _doomMain.ReInit(_context, _gameConfig);
     // Override cvars with values from gameConfig
     initHUD();


### PR DESCRIPTION
- Fix blocked `Iter()` after a restart due to game states
- Fix singletics status after a restart